### PR TITLE
Fix double-speed clock issue by preventing multiple setInterval insta…

### DIFF
--- a/src/routes/Clock.svelte
+++ b/src/routes/Clock.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte'
+	import { onMount, onDestroy } from 'svelte'
 	let time = new Date()
 
 	// these automatically update when `time`
@@ -8,13 +8,30 @@
 	$: minutes = time.getMinutes()
 	$: seconds = time.getSeconds()
 
+	let interval: ReturnType<typeof setInterval> | undefined
+
 	onMount(() => {
-		const interval = setInterval(() => {
+		// Clear any existing interval before creating a new one
+		if (interval) {
+			clearInterval(interval)
+		}
+
+		interval = setInterval(() => {
 			time = new Date()
 		}, 1000)
 
 		return () => {
+			if (interval) {
+				clearInterval(interval)
+				interval = undefined
+			}
+		}
+	})
+
+	onDestroy(() => {
+		if (interval) {
 			clearInterval(interval)
+			interval = undefined
 		}
 	})
 </script>

--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -1,4 +1,5 @@
 <script xmlns="http://www.w3.org/1999/html">
+	import { onDestroy } from 'svelte'
 	import { tweened } from 'svelte/motion'
 	import PauseIcon from 'svelte-icons/md/MdPause.svelte'
 	import PlayIcon from 'svelte-icons/md/MdPlayArrow.svelte'
@@ -9,12 +10,19 @@
 
 	const addTime = [5, 10, 15, 20]
 
-	let countdownInterval = setInterval(() => {
+	let countdownInterval: ReturnType<typeof setInterval> | undefined = setInterval(() => {
 		if ($timer > 0) {
 			$timer--
 		}
 	}, 1000)
 	let running = true
+
+	onDestroy(() => {
+		if (countdownInterval) {
+			clearInterval(countdownInterval)
+			countdownInterval = undefined
+		}
+	})
 
 	const startOrPauseTimer = () => {
 		if (running) {

--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -1,4 +1,4 @@
-<script xmlns="http://www.w3.org/1999/html">
+<script lang="ts">
 	import { onDestroy } from 'svelte'
 	import { tweened } from 'svelte/motion'
 	import PauseIcon from 'svelte-icons/md/MdPause.svelte'

--- a/src/routes/Countdown2.svelte
+++ b/src/routes/Countdown2.svelte
@@ -52,6 +52,10 @@
 
 	// Function to start countdown
 	function startCountdown() {
+		// Clear any existing interval before starting a new one
+		if (interval) {
+			clearInterval(interval)
+		}
 		interval = setInterval(() => {
 			if (totalSeconds > 0) {
 				totalSeconds--


### PR DESCRIPTION
The clock was running at double speed when multiple setInterval instances were running simultaneously. This occurred during Hot Module Replacement (HMR) or when components were re-mounted without proper cleanup.

Changes:
- Clock.svelte: Added onDestroy lifecycle hook and interval guard to prevent duplicate intervals
- Countdown.svelte: Added onDestroy lifecycle hook for proper cleanup
- Countdown2.svelte: Added interval guard in startCountdown() to clear existing intervals before creating new ones

https://claude.ai/code/session_013nb6FXjParq3yE7Z7c7eJT