### PR TITLE
fix(countdown): prevent multiple intervals and state desynchronization

### DIFF
--- a/src/routes/Countdown.svelte
+++ b/src/routes/Countdown.svelte
@@ -9,51 +9,69 @@
 
 	const addTime = [5, 10, 15, 20]
 
-	let countdownInterval = setInterval(() => {
-		if ($timer > 0) {
-			$timer--
+	let countdownInterval: ReturnType<typeof setInterval> | null = null
+	let running = false
+
+	const clearExistingInterval = () => {
+		if (countdownInterval) {
+			clearInterval(countdownInterval)
+			countdownInterval = null
 		}
-	}, 1000)
-	let running = true
+	}
+
+	const startTimer = () => {
+		clearExistingInterval()
+		countdownInterval = setInterval(() => {
+			if ($timer > 0) {
+				$timer--
+			} else {
+				clearExistingInterval()
+				running = false
+			}
+		}, 1000)
+		running = true
+	}
+
+	const pauseTimer = () => {
+		clearExistingInterval()
+		running = false
+	}
 
 	const startOrPauseTimer = () => {
 		if (running) {
-			clearInterval(countdownInterval)
-			running = false
+			pauseTimer()
 		} else {
-			countdownInterval = setInterval(() => {
-				if ($timer > 0) {
-					$timer--
-				}
-			}, 1000)
-			running = true
+			startTimer()
 		}
 	}
 
 	const stopTimer = () => {
+		clearExistingInterval()
 		$timer = original
-		clearInterval(countdownInterval)
 		running = false
 	}
 
 	const setMinutes = (event: Event) => {
 		const target = event.target as HTMLInputElement
+		clearExistingInterval()
 		original = parseInt(target.value) * 60 + seconds
-		timer = tweened(original)
+		$timer = original
 		running = false
 	}
 
 	const setSeconds = (event: Event) => {
 		const target = event.target as HTMLInputElement
+		clearExistingInterval()
 		original = minutes * 60 + parseInt(target.value)
-		timer = tweened(original)
+		$timer = original
 		running = false
 	}
 
 	const setTime = (event: MouseEvent) => {
 		const target = event.currentTarget as HTMLButtonElement
+		clearExistingInterval()
 		original = parseInt(target.value) * 60
-		timer = tweened(original)
+		$timer = original
 		running = false
 	}
 
@@ -71,7 +89,6 @@
 				min="0"
 				max="60"
 				on:blur={(event) => setMinutes(event)}
-				on:click={() => clearInterval(countdownInterval)}
 			/>
 			<span class="divider">:</span>
 			<input
@@ -81,7 +98,6 @@
 				on:blur={(event) => setSeconds(event)}
 				min="0"
 				max="60"
-				on:click={() => clearInterval(countdownInterval)}
 			/>
 		</div>
 		<div class="buttongroup">


### PR DESCRIPTION
Bug Fixes:
- Fix double speed timer when clicking minute buttons then play
- Fix auto-start on page load (timer now starts paused)
- Fix state desync between UI and actual timer state
- Fix memory leak from multiple concurrent intervals
- Fix improper cleanup when setting time

Changes:
- Add clearExistingInterval() helper function
- Remove auto-start on component initialization
- Ensure all time-setting functions clear interval and update state
- Proper cleanup before starting new interval
- Timer now stops when reaching 0
- Remove redundant on:click handlers from inputs (blur handlers sufficient)

Technical Details:
- countdownInterval now properly typed as ReturnType<typeof setInterval> | null
- running state always synchronized with actual interval state
- Centralized interval management prevents race conditions